### PR TITLE
fix: Handle nested gRPC calls better

### DIFF
--- a/client_interceptors.go
+++ b/client_interceptors.go
@@ -2,6 +2,7 @@ package grpc_sentry
 
 import (
 	"context"
+
 	"google.golang.org/grpc/metadata"
 
 	"github.com/getsentry/sentry-go"
@@ -26,7 +27,7 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 
 		span := sentry.StartSpan(ctx, "grpc.client")
 		ctx = span.Context()
-		md := metadata.Pairs("sentry-trace", span.ToSentryTrace())
+		md := metadata.Pairs("sentry-trace", span.ToSentryTrace(), "sentry-tx-name", hub.Scope().Transaction())
 		ctx = metadata.NewOutgoingContext(ctx, md)
 		defer span.Finish()
 


### PR DESCRIPTION
If in the course of handling one gRPC call another is made, the hubs
transaction name would be clobbered by the most recent gRPC calls
FullMethod. This appends the root transaction name to the gRPC metadata
so that we can send the root transaction name as the original call being
handled that resulted in the later spans.
